### PR TITLE
Fix picomatch vulnerability via yarn resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "react-router-dom": "^7.13.0"
   },
   "resolutions": {
-    "minimatch": "^9.0.7"
+    "minimatch": "^9.0.7",
+    "picomatch": ">=2.3.2"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3657,15 +3657,10 @@ picocolors@1.1.1, picocolors@^1.1.1:
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
-
-picomatch@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
-  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
+picomatch@>=2.3.2, picomatch@^2.3.1, picomatch@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
+  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
 plotly.js-basic-dist@^3.3.1:
   version "3.3.1"


### PR DESCRIPTION
## Summary
- Adds `picomatch` `>=2.3.2` to yarn resolutions to fix security vulnerability
- Dependabot could not auto-fix this due to conflicting transitive dependencies from vite, vitest, and typescript-eslint
- All 85 tests pass with the updated dependency

## Test plan
- [x] `yarn install` succeeds
- [x] `yarn list --pattern picomatch` shows only 4.0.4 (above fixed version 2.3.2)
- [x] All 85 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)