### PR TITLE
Add Bootswatch theme support with Cosmo and Litera options

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@tanstack/react-query": "^5.90.20",
     "axios": "^1.13.5",
     "bootstrap": "^5.3.8",
+    "bootswatch": "^5.3.8",
     "es6-promise": "^4.2.8",
     "isomorphic-fetch": "^3.0.0",
     "js-cookie": "^3.0.5",

--- a/src/root.jsx
+++ b/src/root.jsx
@@ -8,8 +8,8 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 // THEME SELECTION - uncomment ONE:
 // import "bootstrap/dist/css/bootstrap.css";           // Default Bootstrap
-import "bootswatch/dist/cosmo/bootstrap.css"; //        Cosmo - bold, modern
-// import "bootswatch/dist/litera/bootstrap.css";       // Litera - light, elegant
+// import "bootswatch/dist/cosmo/bootstrap.css"; //        Cosmo - bold, modern
+import "bootswatch/dist/litera/bootstrap.css";       // Litera - light, elegant
 import { createRoot } from "react-dom/client";
 
 import { App } from "./components/App";

--- a/src/root.jsx
+++ b/src/root.jsx
@@ -6,7 +6,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import "bootstrap/dist/css/bootstrap.css";
+// THEME SELECTION - uncomment ONE:
+// import "bootstrap/dist/css/bootstrap.css";           // Default Bootstrap
+import "bootswatch/dist/cosmo/bootstrap.css"; //        Cosmo - bold, modern
+// import "bootswatch/dist/litera/bootstrap.css";       // Litera - light, elegant
 import { createRoot } from "react-dom/client";
 
 import { App } from "./components/App";

--- a/src/styles/local.css
+++ b/src/styles/local.css
@@ -52,9 +52,9 @@
   .transactions-table tbody tr {
     display: block;
     margin-bottom: 1rem;
-    border: 1px solid #dee2e6;
+    border: 1px solid var(--bs-border-color);
     border-radius: 0.375rem;
-    background-color: #fff;
+    background-color: var(--bs-body-bg);
     box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
   }
 
@@ -64,7 +64,7 @@
     align-items: center;
     padding: 0.75rem;
     border: none;
-    border-bottom: 1px solid #dee2e6;
+    border-bottom: 1px solid var(--bs-border-color);
     text-align: right;
   }
 
@@ -109,7 +109,7 @@
 
 /* Recategorise focus row */
 .recategorise-focus-row {
-  outline: 2px solid #0d6efd;
+  outline: 2px solid var(--bs-primary);
   outline-offset: -2px;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1571,6 +1571,11 @@ bootstrap@^5.3.8:
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.3.8.tgz#6401a10057a22752d21f4e19055508980656aeed"
   integrity sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==
 
+bootswatch@^5.3.8:
+  version "5.3.8"
+  resolved "https://registry.yarnpkg.com/bootswatch/-/bootswatch-5.3.8.tgz#534538ce50285e52cb715823f8b4d734f73956e7"
+  integrity sha512-88mnH9tv+x6DV+scBxYFOpM4YSDVhyfEgbhqaEfvkHNctKI9qRcACxIP9nmBZ5mSeLXtsgax1VsRkUs1eWjlAQ==
+
 brace-expansion@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.3.tgz#0493338bdd58e319b1039c67cf7ee439892c01d9"


### PR DESCRIPTION
Install bootswatch and configure root.jsx with a theme toggle to easily
switch between Cosmo (bold, modern) and Litera (light, elegant) themes.
Replace hardcoded Bootstrap hex colors in local.css with CSS custom
properties (--bs-primary, --bs-border-color, --bs-body-bg) so styles
adapt correctly to any theme.

https://claude.ai/code/session_01WQzvKKB3KxTtU25hNeib6H