### PR TITLE
Add default model section to Preferences page

### DIFF
--- a/src/components/DefaultModelSection.tsx
+++ b/src/components/DefaultModelSection.tsx
@@ -1,0 +1,105 @@
+import { useState } from "react";
+import { Alert, Form } from "react-bootstrap";
+
+import { useCategorisorList } from "../hooks/useCategorisorList";
+import { useUserSettings } from "../hooks/useUserSettings";
+
+export function DefaultModelSection(): JSX.Element | null {
+  const {
+    data: settings,
+    isLoading: settingsLoading,
+    error: settingsError,
+    updateDefaultModel,
+  } = useUserSettings();
+  const {
+    data: models,
+    isLoading: modelsLoading,
+    error: modelsError,
+  } = useCategorisorList();
+
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  if (settingsLoading || modelsLoading) return null;
+
+  const fetchError = settingsError || modelsError;
+  if (fetchError) {
+    return (
+      <Alert variant="danger">
+        Failed to load user settings: {(fetchError as Error).message}
+      </Alert>
+    );
+  }
+
+  const currentModel = models?.find(
+    (m) => m.id === settings?.selected_categorisor,
+  );
+
+  const handleChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value;
+    const newId = value === "" ? null : Number(value);
+    setIsSaving(true);
+    setError(null);
+    setSuccessMessage(null);
+    try {
+      await updateDefaultModel(newId);
+      const modelName = models?.find((m) => m.id === newId)?.name;
+      setSuccessMessage(
+        newId ? `Default model set to "${modelName}".` : "Default model cleared.",
+      );
+    } catch (e: unknown) {
+      setError((e as Error).message);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div>
+      <h4>Default Model</h4>
+
+      {error && (
+        <Alert variant="danger" dismissible onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+
+      {successMessage && (
+        <Alert
+          variant="success"
+          dismissible
+          onClose={() => setSuccessMessage(null)}
+        >
+          {successMessage}
+        </Alert>
+      )}
+
+      {currentModel ? (
+        <p>
+          Current default: <strong>{currentModel.name}</strong> (
+          {currentModel.implementation}, {currentModel.from_date} to{" "}
+          {currentModel.to_date})
+        </p>
+      ) : (
+        <p>No default model set.</p>
+      )}
+
+      <Form.Group className="mb-3" controlId="defaultModelSelect">
+        <Form.Label>Select default model</Form.Label>
+        <Form.Select
+          value={settings?.selected_categorisor ?? ""}
+          onChange={handleChange}
+          disabled={isSaving}
+        >
+          <option value="">None</option>
+          {models?.map((m) => (
+            <option key={m.id} value={m.id}>
+              {m.name} ({m.implementation})
+            </option>
+          ))}
+        </Form.Select>
+      </Form.Group>
+    </div>
+  );
+}

--- a/src/components/Preferences.tsx
+++ b/src/components/Preferences.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import { Alert, Button } from "react-bootstrap";
 
+import { useQueryClient } from "@tanstack/react-query";
+
 import {
   CrossValidateRequest,
   CrossValidateResult,
@@ -9,11 +11,13 @@ import {
 import { useCrossValidation } from "../hooks/useCrossValidation";
 import { CrossValidationForm } from "./CrossValidationForm";
 import { CrossValidationResults } from "./CrossValidationResults";
+import { DefaultModelSection } from "./DefaultModelSection";
 import { SaveModelModal, SaveModelValues } from "./SaveModelModal";
 
 export function Preferences(): JSX.Element {
   const { runCrossValidation, saveModel, setDefaultModel } =
     useCrossValidation();
+  const queryClient = useQueryClient();
 
   const [isRunning, setIsRunning] = useState(false);
   const [result, setResult] = useState<CrossValidateResult | null>(null);
@@ -28,6 +32,7 @@ export function Preferences(): JSX.Element {
     if (!savedModel) return;
     try {
       await setDefaultModel(savedModel.id);
+      await queryClient.invalidateQueries({ queryKey: ["userSettings"] });
       setSavedModel(null);
       setSuccessMessage(
         `Model "${savedModel.name}" is now the default.`,
@@ -72,6 +77,10 @@ export function Preferences(): JSX.Element {
         }),
       };
       const saved = await saveModel(request);
+      await queryClient.invalidateQueries({ queryKey: ["categorisors"] });
+      if (values.set_as_default) {
+        await queryClient.invalidateQueries({ queryKey: ["userSettings"] });
+      }
       setShowSaveModal(false);
       setResult(null);
       setSavedModel(values.set_as_default ? null : saved);
@@ -90,6 +99,10 @@ export function Preferences(): JSX.Element {
   return (
     <div>
       <h2>Preferences</h2>
+
+      <DefaultModelSection />
+      <hr />
+
       <h4>Model Calibration</h4>
 
       {error && (

--- a/src/components/__tests__/TestDefaultModelSection.tsx
+++ b/src/components/__tests__/TestDefaultModelSection.tsx
@@ -39,12 +39,7 @@ const mockSettingsNoModel: UserSettings = {
 
 function setupWithModel(mockAdapter: AxiosMockAdapter) {
   mockAdapter.onGet("/api/user-settings/me/").reply(200, mockSettingsWithModel);
-  mockAdapter.onGet("/api/categorisor/").reply(200, {
-    count: 2,
-    next: null,
-    previous: null,
-    results: mockModels,
-  });
+  mockAdapter.onGet("/api/categorisor/").reply(200, mockModels);
   mockAdapter.onPatch("/api/user-settings/me/").reply(200, {
     id: 1,
     selected_categorisor: 2,
@@ -53,12 +48,7 @@ function setupWithModel(mockAdapter: AxiosMockAdapter) {
 
 function setupNoModel(mockAdapter: AxiosMockAdapter) {
   mockAdapter.onGet("/api/user-settings/me/").reply(200, mockSettingsNoModel);
-  mockAdapter.onGet("/api/categorisor/").reply(200, {
-    count: 2,
-    next: null,
-    previous: null,
-    results: mockModels,
-  });
+  mockAdapter.onGet("/api/categorisor/").reply(200, mockModels);
   mockAdapter.onPatch("/api/user-settings/me/").reply(200, {
     id: 1,
     selected_categorisor: 1,
@@ -143,12 +133,7 @@ describe("DefaultModelSection", () => {
         mockAdapter
           .onGet("/api/user-settings/me/")
           .reply(200, mockSettingsWithModel);
-        mockAdapter.onGet("/api/categorisor/").reply(200, {
-          count: 2,
-          next: null,
-          previous: null,
-          results: mockModels,
-        });
+        mockAdapter.onGet("/api/categorisor/").reply(200, mockModels);
         mockAdapter.onPatch("/api/user-settings/me/").networkError();
       },
     );
@@ -174,12 +159,7 @@ describe("DefaultModelSection", () => {
       undefined,
       (mockAdapter: AxiosMockAdapter) => {
         mockAdapter.onGet("/api/user-settings/me/").networkError();
-        mockAdapter.onGet("/api/categorisor/").reply(200, {
-          count: 0,
-          next: null,
-          previous: null,
-          results: [],
-        });
+        mockAdapter.onGet("/api/categorisor/").reply(200, []);
       },
     );
 

--- a/src/components/__tests__/TestDefaultModelSection.tsx
+++ b/src/components/__tests__/TestDefaultModelSection.tsx
@@ -1,0 +1,190 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { describe, expect, it } from "vitest";
+
+import { renderWithProviders } from "../../RenderWithProviders";
+import { SavedModel } from "../../data/CrossValidation";
+import { UserSettings } from "../../data/UserSettings";
+import { DefaultModelSection } from "../DefaultModelSection";
+
+const mockModels: SavedModel[] = [
+  {
+    url: "http://localhost:8000/api/categorisor/1/",
+    id: 1,
+    name: "model-a",
+    implementation: "SklearnCategoriser",
+    from_date: "2025-01-01",
+    to_date: "2025-06-30",
+  },
+  {
+    url: "http://localhost:8000/api/categorisor/2/",
+    id: 2,
+    name: "model-b",
+    implementation: "SklearnCategoriser",
+    from_date: "2025-01-01",
+    to_date: "2025-12-31",
+  },
+];
+
+const mockSettingsWithModel: UserSettings = {
+  id: 1,
+  selected_categorisor: 1,
+};
+
+const mockSettingsNoModel: UserSettings = {
+  id: 1,
+  selected_categorisor: null,
+};
+
+function setupWithModel(mockAdapter: AxiosMockAdapter) {
+  mockAdapter.onGet("/api/user-settings/me/").reply(200, mockSettingsWithModel);
+  mockAdapter.onGet("/api/categorisor/").reply(200, {
+    count: 2,
+    next: null,
+    previous: null,
+    results: mockModels,
+  });
+  mockAdapter.onPatch("/api/user-settings/me/").reply(200, {
+    id: 1,
+    selected_categorisor: 2,
+  });
+}
+
+function setupNoModel(mockAdapter: AxiosMockAdapter) {
+  mockAdapter.onGet("/api/user-settings/me/").reply(200, mockSettingsNoModel);
+  mockAdapter.onGet("/api/categorisor/").reply(200, {
+    count: 2,
+    next: null,
+    previous: null,
+    results: mockModels,
+  });
+  mockAdapter.onPatch("/api/user-settings/me/").reply(200, {
+    id: 1,
+    selected_categorisor: 1,
+  });
+}
+
+describe("DefaultModelSection", () => {
+  it("should display current default model details", async () => {
+    renderWithProviders(<DefaultModelSection />, undefined, setupWithModel);
+
+    await waitFor(() => {
+      expect(screen.getByText("Default Model")).toBeTruthy();
+      expect(
+        screen.getByText(/Current default:/),
+      ).toBeTruthy();
+      expect(screen.getByText("model-a")).toBeTruthy();
+    });
+  });
+
+  it("should show no default model message when none set", async () => {
+    renderWithProviders(<DefaultModelSection />, undefined, setupNoModel);
+
+    await waitFor(() => {
+      expect(screen.getByText("No default model set.")).toBeTruthy();
+    });
+  });
+
+  it("should show available models in dropdown", async () => {
+    renderWithProviders(<DefaultModelSection />, undefined, setupWithModel);
+
+    await waitFor(() => {
+      const select = screen.getByLabelText(
+        "Select default model",
+      ) as HTMLSelectElement;
+      expect(select).toBeTruthy();
+      expect(select.options).toHaveLength(3); // None + 2 models
+      expect(select.value).toBe("1");
+    });
+  });
+
+  it("should change default model on dropdown change", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<DefaultModelSection />, undefined, setupWithModel);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Select default model")).toBeTruthy();
+    });
+
+    await user.selectOptions(screen.getByLabelText("Select default model"), "2");
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Default model set to "model-b".'),
+      ).toBeTruthy();
+    });
+  });
+
+  it("should show success message when clearing default model", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<DefaultModelSection />, undefined, setupWithModel);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Select default model")).toBeTruthy();
+    });
+
+    await user.selectOptions(
+      screen.getByLabelText("Select default model"),
+      "",
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Default model cleared.")).toBeTruthy();
+    });
+  });
+
+  it("should show error when update fails", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <DefaultModelSection />,
+      undefined,
+      (mockAdapter: AxiosMockAdapter) => {
+        mockAdapter
+          .onGet("/api/user-settings/me/")
+          .reply(200, mockSettingsWithModel);
+        mockAdapter.onGet("/api/categorisor/").reply(200, {
+          count: 2,
+          next: null,
+          previous: null,
+          results: mockModels,
+        });
+        mockAdapter.onPatch("/api/user-settings/me/").networkError();
+      },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Select default model")).toBeTruthy();
+    });
+
+    await user.selectOptions(screen.getByLabelText("Select default model"), "2");
+
+    await waitFor(() => {
+      const alerts = screen.getAllByRole("alert");
+      const dangerAlert = alerts.find((el) =>
+        el.classList.contains("alert-danger"),
+      );
+      expect(dangerAlert).toBeTruthy();
+    });
+  });
+
+  it("should show fetch error when settings endpoint fails", async () => {
+    renderWithProviders(
+      <DefaultModelSection />,
+      undefined,
+      (mockAdapter: AxiosMockAdapter) => {
+        mockAdapter.onGet("/api/user-settings/me/").networkError();
+        mockAdapter.onGet("/api/categorisor/").reply(200, {
+          count: 0,
+          next: null,
+          previous: null,
+          results: [],
+        });
+      },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to load user settings/)).toBeTruthy();
+    });
+  });
+});

--- a/src/components/__tests__/TestPreferences.tsx
+++ b/src/components/__tests__/TestPreferences.tsx
@@ -38,12 +38,7 @@ function setupDefaultModelMocks(mockAdapter: AxiosMockAdapter) {
   mockAdapter
     .onGet("/api/user-settings/me/")
     .reply(200, { id: 1, selected_categorisor: null });
-  mockAdapter.onGet("/api/categorisor/").reply(200, {
-    count: 1,
-    next: null,
-    previous: null,
-    results: [mockSavedModel],
-  });
+  mockAdapter.onGet("/api/categorisor/").reply(200, [mockSavedModel]);
   mockAdapter
     .onPatch("/api/user-settings/me/")
     .reply(200, { id: 1, selected_categorisor: 5 });

--- a/src/components/__tests__/TestPreferences.tsx
+++ b/src/components/__tests__/TestPreferences.tsx
@@ -34,7 +34,23 @@ const mockSavedModel: SavedModel = {
   to_date: "2025-12-31",
 };
 
+function setupDefaultModelMocks(mockAdapter: AxiosMockAdapter) {
+  mockAdapter
+    .onGet("/api/user-settings/me/")
+    .reply(200, { id: 1, selected_categorisor: null });
+  mockAdapter.onGet("/api/categorisor/").reply(200, {
+    count: 1,
+    next: null,
+    previous: null,
+    results: [mockSavedModel],
+  });
+  mockAdapter
+    .onPatch("/api/user-settings/me/")
+    .reply(200, { id: 1, selected_categorisor: 5 });
+}
+
 function setup(mockAdapter: AxiosMockAdapter) {
+  setupDefaultModelMocks(mockAdapter);
   mockAdapter
     .onPost("/api/categorisor/cross_validate/")
     .reply(200, mockResult);
@@ -47,6 +63,7 @@ function setup(mockAdapter: AxiosMockAdapter) {
 }
 
 function setupError(mockAdapter: AxiosMockAdapter) {
+  setupDefaultModelMocks(mockAdapter);
   mockAdapter.onPost("/api/categorisor/cross_validate/").reply(200, {
     status: "error",
     message: "Insufficient transactions for cross-validation.",
@@ -210,6 +227,7 @@ describe("Preferences", () => {
       <Preferences />,
       undefined,
       (mockAdapter: AxiosMockAdapter) => {
+        setupDefaultModelMocks(mockAdapter);
         mockAdapter
           .onPost("/api/categorisor/cross_validate/")
           .reply(200, mockResult);
@@ -244,6 +262,7 @@ describe("Preferences", () => {
       <Preferences />,
       undefined,
       (mockAdapter: AxiosMockAdapter) => {
+        setupDefaultModelMocks(mockAdapter);
         mockAdapter
           .onPost("/api/categorisor/cross_validate/")
           .reply(200, mockResult);
@@ -294,6 +313,7 @@ describe("Preferences", () => {
       <Preferences />,
       undefined,
       (mockAdapter: AxiosMockAdapter) => {
+        setupDefaultModelMocks(mockAdapter);
         mockAdapter
           .onPost("/api/categorisor/cross_validate/")
           .reply(200, mockResult);

--- a/src/data/UserSettings.ts
+++ b/src/data/UserSettings.ts
@@ -1,0 +1,4 @@
+export interface UserSettings {
+  id: number;
+  selected_categorisor: number | null;
+}

--- a/src/hooks/__tests__/TestUseCategorisorList.tsx
+++ b/src/hooks/__tests__/TestUseCategorisorList.tsx
@@ -42,12 +42,7 @@ describe("useCategorisorList", () => {
       <TestHarness />,
       undefined,
       (mockAdapter: AxiosMockAdapter) => {
-        mockAdapter.onGet("/api/categorisor/").reply(200, {
-          count: 2,
-          next: null,
-          previous: null,
-          results: mockModels,
-        });
+        mockAdapter.onGet("/api/categorisor/").reply(200, mockModels);
       },
     );
 

--- a/src/hooks/__tests__/TestUseCategorisorList.tsx
+++ b/src/hooks/__tests__/TestUseCategorisorList.tsx
@@ -1,0 +1,76 @@
+import { screen, waitFor } from "@testing-library/react";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { describe, expect, it } from "vitest";
+
+import { renderWithProviders } from "../../RenderWithProviders";
+import { SavedModel } from "../../data/CrossValidation";
+import { useCategorisorList } from "../useCategorisorList";
+
+const mockModels: SavedModel[] = [
+  {
+    url: "http://localhost:8000/api/categorisor/1/",
+    id: 1,
+    name: "model-a",
+    implementation: "SklearnCategoriser",
+    from_date: "2025-01-01",
+    to_date: "2025-06-30",
+  },
+  {
+    url: "http://localhost:8000/api/categorisor/2/",
+    id: 2,
+    name: "model-b",
+    implementation: "SklearnCategoriser",
+    from_date: "2025-01-01",
+    to_date: "2025-12-31",
+  },
+];
+
+function TestHarness() {
+  const { data, isLoading, error } = useCategorisorList();
+
+  if (isLoading) return <div data-testid="loading">Loading</div>;
+  if (error) return <div data-testid="error">{(error as Error).message}</div>;
+
+  return (
+    <div data-testid="models">{JSON.stringify(data)}</div>
+  );
+}
+
+describe("useCategorisorList", () => {
+  it("should fetch categorisor list from paginated response", async () => {
+    renderWithProviders(
+      <TestHarness />,
+      undefined,
+      (mockAdapter: AxiosMockAdapter) => {
+        mockAdapter.onGet("/api/categorisor/").reply(200, {
+          count: 2,
+          next: null,
+          previous: null,
+          results: mockModels,
+        });
+      },
+    );
+
+    await waitFor(() => {
+      const output = screen.getByTestId("models").textContent!;
+      const parsed = JSON.parse(output);
+      expect(parsed).toHaveLength(2);
+      expect(parsed[0].name).toBe("model-a");
+      expect(parsed[1].name).toBe("model-b");
+    });
+  });
+
+  it("should handle fetch error", async () => {
+    renderWithProviders(
+      <TestHarness />,
+      undefined,
+      (mockAdapter: AxiosMockAdapter) => {
+        mockAdapter.onGet("/api/categorisor/").networkError();
+      },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("error")).toBeTruthy();
+    });
+  });
+});

--- a/src/hooks/__tests__/TestUseUserSettings.tsx
+++ b/src/hooks/__tests__/TestUseUserSettings.tsx
@@ -1,0 +1,126 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { describe, expect, it } from "vitest";
+
+import { renderWithProviders } from "../../RenderWithProviders";
+import { UserSettings } from "../../data/UserSettings";
+import { useUserSettings } from "../useUserSettings";
+
+const mockSettings: UserSettings = {
+  id: 1,
+  selected_categorisor: 3,
+};
+
+function TestHarness() {
+  const { data, isLoading, error, updateDefaultModel } = useUserSettings();
+
+  const handleUpdate = async () => {
+    try {
+      const result = await updateDefaultModel(7);
+      document.getElementById("output")!.textContent = JSON.stringify(result);
+    } catch (e: unknown) {
+      document.getElementById("output")!.textContent = `error:${(e as Error).message}`;
+    }
+  };
+
+  const handleClear = async () => {
+    try {
+      const result = await updateDefaultModel(null);
+      document.getElementById("output")!.textContent = JSON.stringify(result);
+    } catch (e: unknown) {
+      document.getElementById("output")!.textContent = `error:${(e as Error).message}`;
+    }
+  };
+
+  if (isLoading) return <div data-testid="loading">Loading</div>;
+  if (error) return <div data-testid="error">{(error as Error).message}</div>;
+
+  return (
+    <div>
+      <div data-testid="settings">{JSON.stringify(data)}</div>
+      <button onClick={handleUpdate}>Update</button>
+      <button onClick={handleClear}>Clear</button>
+      <div id="output" data-testid="output"></div>
+    </div>
+  );
+}
+
+function setup(mockAdapter: AxiosMockAdapter) {
+  mockAdapter.onGet("/api/user-settings/me/").reply(200, mockSettings);
+  mockAdapter.onPatch("/api/user-settings/me/").reply(200, {
+    id: 1,
+    selected_categorisor: 7,
+  });
+}
+
+describe("useUserSettings", () => {
+  it("should fetch user settings", async () => {
+    renderWithProviders(<TestHarness />, undefined, setup);
+
+    await waitFor(() => {
+      const output = screen.getByTestId("settings").textContent!;
+      const parsed = JSON.parse(output);
+      expect(parsed.id).toBe(1);
+      expect(parsed.selected_categorisor).toBe(3);
+    });
+  });
+
+  it("should update default model", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<TestHarness />, undefined, setup);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("settings")).toBeTruthy();
+    });
+
+    await user.click(screen.getByText("Update"));
+
+    await waitFor(() => {
+      const output = screen.getByTestId("output").textContent!;
+      const parsed = JSON.parse(output);
+      expect(parsed.selected_categorisor).toBe(7);
+    });
+  });
+
+  it("should clear default model", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <TestHarness />,
+      undefined,
+      (mockAdapter: AxiosMockAdapter) => {
+        mockAdapter.onGet("/api/user-settings/me/").reply(200, mockSettings);
+        mockAdapter.onPatch("/api/user-settings/me/").reply(200, {
+          id: 1,
+          selected_categorisor: null,
+        });
+      },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("settings")).toBeTruthy();
+    });
+
+    await user.click(screen.getByText("Clear"));
+
+    await waitFor(() => {
+      const output = screen.getByTestId("output").textContent!;
+      const parsed = JSON.parse(output);
+      expect(parsed.selected_categorisor).toBeNull();
+    });
+  });
+
+  it("should handle fetch error", async () => {
+    renderWithProviders(
+      <TestHarness />,
+      undefined,
+      (mockAdapter: AxiosMockAdapter) => {
+        mockAdapter.onGet("/api/user-settings/me/").networkError();
+      },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("error")).toBeTruthy();
+    });
+  });
+});

--- a/src/hooks/useCategorisorList.ts
+++ b/src/hooks/useCategorisorList.ts
@@ -10,10 +10,6 @@ export function useCategorisorList() {
   return useQuery<SavedModel[]>({
     queryKey: ["categorisors"],
     queryFn: () =>
-      axios
-        .get("/api/categorisor/")
-        .then(checkStatusAxios)
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .then((data: any) => data.results as SavedModel[]),
+      axios.get("/api/categorisor/").then(checkStatusAxios),
   });
 }

--- a/src/hooks/useCategorisorList.ts
+++ b/src/hooks/useCategorisorList.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { checkStatusAxios } from "../client/CatTrackAPI";
+import { SavedModel } from "../data/CrossValidation";
+import { useAxios } from "./AxiosContext";
+
+export function useCategorisorList() {
+  const axios = useAxios();
+
+  return useQuery<SavedModel[]>({
+    queryKey: ["categorisors"],
+    queryFn: () =>
+      axios
+        .get("/api/categorisor/")
+        .then(checkStatusAxios)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .then((data: any) => data.results as SavedModel[]),
+  });
+}

--- a/src/hooks/useUserSettings.ts
+++ b/src/hooks/useUserSettings.ts
@@ -1,0 +1,29 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { checkStatusAxios } from "../client/CatTrackAPI";
+import { UserSettings } from "../data/UserSettings";
+import { useAxios } from "./AxiosContext";
+
+export function useUserSettings() {
+  const axios = useAxios();
+  const queryClient = useQueryClient();
+
+  const query = useQuery<UserSettings>({
+    queryKey: ["userSettings"],
+    queryFn: () =>
+      axios.get("/api/user-settings/me/").then(checkStatusAxios),
+  });
+
+  const updateDefaultModel = async (
+    categorisorId: number | null,
+  ): Promise<UserSettings> => {
+    const response = await axios.patch("/api/user-settings/me/", {
+      selected_categorisor: categorisorId,
+    });
+    const result: UserSettings = checkStatusAxios(response);
+    await queryClient.invalidateQueries({ queryKey: ["userSettings"] });
+    return result;
+  };
+
+  return { ...query, updateDefaultModel };
+}


### PR DESCRIPTION
## Summary
- Adds a "Default Model" section to the Preferences page that displays the current default categoriser model and allows changing it via a dropdown
- New `useUserSettings` hook fetches/updates `GET/PATCH /api/user-settings/me/` and new `useCategorisorList` hook fetches available models
- Invalidates user settings cache when models are saved or set as default through the existing cross-validation flow

## Test plan
- [x] All 134 existing + new tests pass (`yarn test`)
- [x] Production build succeeds (`yarn build`)
- [ ] Manual: visit `/preferences`, verify default model section renders with dropdown
- [ ] Manual: change default model via dropdown, verify success message and persistence on reload
- [ ] Manual: save a model with "set as default" checked, verify the Default Model section updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)