### PR TITLE
Add category spend progress tracking page

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -17,8 +17,9 @@ import { Login } from "./Login";
 import { NavComponent } from "./NavComponent";
 import { PaymentSeries } from "./PaymentSeries";
 import { Preferences } from "./Preferences";
-import { Tracking } from "./Tracking";
 import { Recategorise } from "./Recategorise";
+import { SpendProgress } from "./SpendProgress";
+import { Tracking } from "./Tracking";
 import { Transactions } from "./Transactions";
 
 interface RequireAuthProps {
@@ -76,6 +77,14 @@ export function App(): JSX.Element {
                     element={
                       <RequireAuth redirectTo="/login">
                         <Recategorise />
+                      </RequireAuth>
+                    }
+                  />
+                  <Route
+                    path="/progress"
+                    element={
+                      <RequireAuth redirectTo="/login">
+                        <SpendProgress />
                       </RequireAuth>
                     }
                   />

--- a/src/components/NavComponent.tsx
+++ b/src/components/NavComponent.tsx
@@ -23,6 +23,9 @@ export function NavComponent(): JSX.Element {
           <Nav.Link as={Link} to="/tracking">
             Tracking
           </Nav.Link>
+          <Nav.Link as={Link} to="/progress">
+            Progress
+          </Nav.Link>
           <Nav.Link as={Link} to="/transactions">
             Transactions
           </Nav.Link>

--- a/src/components/SpendProgress.tsx
+++ b/src/components/SpendProgress.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useState } from "react";
+import { Button, ButtonGroup, Col, Container, Row } from "react-bootstrap";
+
+import {
+  PeriodFilters,
+  createDefaultPeriodFilters,
+} from "../data/TransactionFilters";
+import { usePeriods } from "../hooks/usePeriods";
+import { ProgressGroupBy, useProgress } from "../hooks/useProgress";
+import {
+  loadPeriodFiltersFromCookie,
+  savePeriodFiltersToCookie,
+} from "../utils/filterCookies";
+import { SpendProgressTable } from "./SpendProgressTable";
+import { TransactionFilterPeriods } from "./TransactionFilterPeriods";
+
+export function SpendProgress(): JSX.Element | null {
+  const { isLoading: isPeriodsLoading, data: periods } = usePeriods();
+  const [filters, setFilters] = useState<PeriodFilters>(() => {
+    return loadPeriodFiltersFromCookie() ?? createDefaultPeriodFilters();
+  });
+  const [groupBy, setGroupBy] = useState<ProgressGroupBy>("category");
+  const { isLoading: isProgressLoading, data: progress } = useProgress({
+    from_date: filters.from_date,
+    to_date: filters.to_date,
+    group_by: groupBy,
+  });
+
+  useEffect(() => {
+    savePeriodFiltersToCookie(filters);
+  }, [filters]);
+
+  if (isPeriodsLoading) {
+    return null;
+  }
+
+  const handleUpdateFilters = (newFilters: Partial<PeriodFilters>) => {
+    setFilters((prevFilters) => ({ ...prevFilters, ...newFilters }));
+  };
+
+  return (
+    <div>
+      <Container>
+        <Row>
+          <Col md={8}>
+            {progress && <h2>{progress.period.label}</h2>}
+            <ButtonGroup className="mb-3">
+              <Button
+                variant={
+                  groupBy === "category" ? "primary" : "outline-primary"
+                }
+                onClick={() => setGroupBy("category")}
+              >
+                By Category
+              </Button>
+              <Button
+                variant={
+                  groupBy === "category_group" ? "primary" : "outline-primary"
+                }
+                onClick={() => setGroupBy("category_group")}
+              >
+                By Group
+              </Button>
+            </ButtonGroup>
+            {progress && (
+              <SpendProgressTable
+                rows={progress.rows}
+                totals={progress.totals}
+              />
+            )}
+            {!progress && !isProgressLoading && (
+              <p className="text-muted">
+                Select a time period to view spend progress.
+              </p>
+            )}
+          </Col>
+          <Col md={2}>
+            <div className="btn-group-vertical" role="group">
+              <TransactionFilterPeriods
+                filters={filters}
+                periods={periods || []}
+                updateFilters={handleUpdateFilters}
+              />
+            </div>
+          </Col>
+        </Row>
+      </Container>
+    </div>
+  );
+}

--- a/src/components/SpendProgressTable.tsx
+++ b/src/components/SpendProgressTable.tsx
@@ -77,9 +77,9 @@ export function SpendProgressTable(
   props: SpendProgressTableProps,
 ): JSX.Element {
   const { rows, totals } = props;
-  const [expanded, setExpanded] = useState<Record<number, boolean>>({});
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
 
-  const toggleExpanded = (id: number) => {
+  const toggleExpanded = (id: ProgressRow["id"]) => {
     setExpanded((prev) => ({ ...prev, [id]: !prev[id] }));
   };
 
@@ -105,14 +105,19 @@ export function SpendProgressTable(
           return (
             <Fragment key={row.id}>
               <tr>
-                <td
-                  style={{ cursor: hasBills ? "pointer" : "default" }}
-                  onClick={() => hasBills && toggleExpanded(row.id)}
-                >
+                <td>
                   {hasBills && (
-                    <FontAwesomeIcon
-                      icon={isExpanded ? faChevronDown : faChevronRight}
-                    />
+                    <button
+                      type="button"
+                      onClick={() => toggleExpanded(row.id)}
+                      aria-label={`${isExpanded ? "Collapse" : "Expand"} ${row.name}`}
+                      aria-expanded={isExpanded}
+                      className="btn btn-link p-0 border-0 text-decoration-none"
+                    >
+                      <FontAwesomeIcon
+                        icon={isExpanded ? faChevronDown : faChevronRight}
+                      />
+                    </button>
                   )}
                 </td>
                 <td>{row.name}</td>

--- a/src/components/SpendProgressTable.tsx
+++ b/src/components/SpendProgressTable.tsx
@@ -1,0 +1,171 @@
+import {
+  faChevronDown,
+  faChevronRight,
+} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Fragment, useState } from "react";
+import { ProgressBar, Table } from "react-bootstrap";
+import { FormattedNumber } from "react-intl";
+
+import { ProgressRow, ProgressTotals, UpcomingBill } from "../data/Progress";
+
+export interface SpendProgressTableProps {
+  rows: ProgressRow[];
+  totals: ProgressTotals;
+}
+
+function progressVariant(
+  actualSpend: number,
+  budget: number,
+): "success" | "warning" | "danger" {
+  const value = (actualSpend / budget) * 80.0;
+  if (value >= 84) {
+    return "danger";
+  } else if (value > 76) {
+    return "warning";
+  }
+  return "success";
+}
+
+const budgetMarker = (
+  <div className="bar-step" style={{ left: "80%" }}>
+    <div className="label-line"></div>
+  </div>
+);
+
+function CurrencyValue({ value }: { value: number }): JSX.Element {
+  return (
+    <FormattedNumber
+      value={value}
+      style="currency"
+      currency="AUD"
+      maximumSignificantDigits={3}
+    />
+  );
+}
+
+function BillsDetail({ bills }: { bills: UpcomingBill[] }): JSX.Element {
+  return (
+    <tr>
+      <td colSpan={6}>
+        <Table size="sm" className="mb-0 ms-4">
+          <thead>
+            <tr>
+              <th>Bill</th>
+              <th>Expected Date</th>
+              <th>Amount</th>
+            </tr>
+          </thead>
+          <tbody>
+            {bills.map((bill, idx) => (
+              <tr key={idx}>
+                <td>{bill.name}</td>
+                <td>{bill.expected_date}</td>
+                <td>
+                  <CurrencyValue value={parseFloat(bill.expected_amount)} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+      </td>
+    </tr>
+  );
+}
+
+export function SpendProgressTable(
+  props: SpendProgressTableProps,
+): JSX.Element {
+  const { rows, totals } = props;
+  const [expanded, setExpanded] = useState<Record<number, boolean>>({});
+
+  const toggleExpanded = (id: number) => {
+    setExpanded((prev) => ({ ...prev, [id]: !prev[id] }));
+  };
+
+  return (
+    <Table striped bordered hover>
+      <thead>
+        <tr>
+          <th></th>
+          <th>Category</th>
+          <th>Spent</th>
+          <th>Progress</th>
+          <th>Budget</th>
+          <th>Expected Remaining</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => {
+          const actualSpend = Math.abs(parseFloat(row.actual_spend));
+          const budget = row.budget ? Math.abs(parseFloat(row.budget)) : null;
+          const hasBills = row.upcoming_bills.length > 0;
+          const isExpanded = expanded[row.id] ?? false;
+
+          return (
+            <Fragment key={row.id}>
+              <tr>
+                <td
+                  style={{ cursor: hasBills ? "pointer" : "default" }}
+                  onClick={() => hasBills && toggleExpanded(row.id)}
+                >
+                  {hasBills && (
+                    <FontAwesomeIcon
+                      icon={isExpanded ? faChevronDown : faChevronRight}
+                    />
+                  )}
+                </td>
+                <td>{row.name}</td>
+                <td>
+                  <CurrencyValue value={actualSpend} />
+                </td>
+                <td>
+                  {budget !== null && budget > 0 ? (
+                    <ProgressBar
+                      variant={progressVariant(actualSpend, budget)}
+                      now={(actualSpend / budget) * 80.0}
+                      label={budgetMarker}
+                    />
+                  ) : null}
+                </td>
+                <td>
+                  {budget !== null ? (
+                    <CurrencyValue value={budget} />
+                  ) : (
+                    <span className="text-muted">No budget</span>
+                  )}
+                </td>
+                <td>
+                  <CurrencyValue
+                    value={Math.abs(parseFloat(row.expected_remaining))}
+                  />
+                </td>
+              </tr>
+              {isExpanded && <BillsDetail bills={row.upcoming_bills} />}
+            </Fragment>
+          );
+        })}
+      </tbody>
+      <tfoot>
+        <tr className="fw-bold">
+          <td></td>
+          <td>Total</td>
+          <td>
+            <CurrencyValue value={Math.abs(parseFloat(totals.actual_spend))} />
+          </td>
+          <td></td>
+          <td>
+            {totals.budget !== null ? (
+              <CurrencyValue value={Math.abs(parseFloat(totals.budget))} />
+            ) : null}
+          </td>
+          <td>
+            <CurrencyValue
+              value={Math.abs(parseFloat(totals.expected_remaining))}
+            />
+          </td>
+        </tr>
+      </tfoot>
+    </Table>
+  );
+}

--- a/src/components/__tests__/TestNavComponent.tsx
+++ b/src/components/__tests__/TestNavComponent.tsx
@@ -36,15 +36,17 @@ describe("components", () => {
   describe("NavComponent", () => {
     it("should render self and subcomponents when logged out", () => {
       setup(false);
-      expect(screen.getAllByRole("link").length).toBe(8);
+      expect(screen.getAllByRole("link").length).toBe(9);
       expect(screen.getByRole("link", { name: "Dashboard" })).toBeTruthy();
       expect(screen.getByRole("link", { name: "Accounts" })).toBeTruthy();
+      expect(screen.getByRole("link", { name: "Progress" })).toBeTruthy();
+      expect(screen.getByRole("link", { name: "Recategorise" })).toBeTruthy();
       expect(screen.getByRole("link", { name: "Login" })).toBeTruthy();
     });
 
     it("should render self and subcomponents when logged in", () => {
       setup(true);
-      expect(screen.getAllByRole("link").length).toBe(9);
+      expect(screen.getAllByRole("link").length).toBe(10);
       expect(screen.getByRole("link", { name: "Dashboard" })).toBeTruthy();
       expect(screen.getByRole("link", { name: "Accounts" })).toBeTruthy();
       expect(screen.getByRole("link", { name: "Preferences" })).toBeTruthy();

--- a/src/components/__tests__/TestSpendProgress.tsx
+++ b/src/components/__tests__/TestSpendProgress.tsx
@@ -1,0 +1,178 @@
+import { screen, waitFor } from "@testing-library/react";
+import Cookies from "js-cookie";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, expect, test } from "vitest";
+
+import { renderWithProviders } from "../../RenderWithProviders";
+import { ProgressResponse } from "../../data/Progress";
+import { SpendProgress } from "../SpendProgress";
+
+const periods = [
+  {
+    id: 4,
+    label: "Last month",
+    from_date: "2026-03-01",
+    to_date: "2026-03-31",
+    offset: "1",
+  },
+  {
+    id: 1,
+    label: "Last week",
+    from_date: "2026-04-07",
+    to_date: "2026-04-14",
+    offset: "1",
+  },
+];
+
+const progressResponse: ProgressResponse = {
+  period: {
+    from_date: "2026-03-01",
+    to_date: "2026-03-31",
+    label: "This month",
+  },
+  rows: [
+    {
+      id: 5,
+      name: "Groceries",
+      actual_spend: "-342.50",
+      expected_remaining: "-157.50",
+      budget: "-500.00",
+      upcoming_bills: [],
+    },
+    {
+      id: 8,
+      name: "Utilities",
+      actual_spend: "-89.00",
+      expected_remaining: "-45.00",
+      budget: "-150.00",
+      upcoming_bills: [
+        {
+          name: "Electricity",
+          expected_date: "2026-04-15",
+          expected_amount: "120.00",
+        },
+      ],
+    },
+    {
+      id: 12,
+      name: "Entertainment",
+      actual_spend: "-50.00",
+      expected_remaining: "-30.00",
+      budget: null,
+      upcoming_bills: [],
+    },
+  ],
+  totals: {
+    actual_spend: "-481.50",
+    expected_remaining: "-232.50",
+    budget: "-650.00",
+  },
+};
+
+beforeEach(() => {
+  Cookies.set(
+    "transactionFilters",
+    JSON.stringify({
+      from_date: "2026-03-01",
+      to_date: "2026-03-31",
+      category: null,
+      has_category: null,
+      account: null,
+      description: null,
+    }),
+  );
+});
+
+afterEach(() => {
+  Cookies.remove("transactionFilters");
+});
+
+function renderSpendProgress() {
+  return renderWithProviders(
+    <SpendProgress />,
+    undefined,
+    (mockAdapter) => {
+      mockAdapter.onGet("/api/periods/").reply(200, periods);
+      mockAdapter.onGet("/api/progress/").reply(200, progressResponse);
+    },
+  );
+}
+
+test("renders progress table with category rows", async () => {
+  renderSpendProgress();
+
+  await waitFor(() => {
+    expect(screen.getByText("Groceries")).toBeInTheDocument();
+  });
+
+  expect(screen.getByText("Utilities")).toBeInTheDocument();
+  expect(screen.getByText("Entertainment")).toBeInTheDocument();
+  expect(screen.getByText("This month")).toBeInTheDocument();
+});
+
+test("renders period selector buttons", async () => {
+  renderSpendProgress();
+
+  await waitFor(() => {
+    expect(screen.getByText("Time")).toBeInTheDocument();
+  });
+
+  expect(screen.getByRole("button", { name: "Last month" })).toBeTruthy();
+  expect(screen.getByRole("button", { name: "Last week" })).toBeTruthy();
+});
+
+test("renders group by toggle buttons", async () => {
+  renderSpendProgress();
+
+  await waitFor(() => {
+    expect(screen.getByText("Groceries")).toBeInTheDocument();
+  });
+
+  expect(
+    screen.getByRole("button", { name: "By Category" }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("button", { name: "By Group" }),
+  ).toBeInTheDocument();
+});
+
+test("shows No budget for rows without budget", async () => {
+  renderSpendProgress();
+
+  await waitFor(() => {
+    expect(screen.getByText("Entertainment")).toBeInTheDocument();
+  });
+
+  expect(screen.getByText("No budget")).toBeInTheDocument();
+});
+
+test("renders totals row", async () => {
+  renderSpendProgress();
+
+  await waitFor(() => {
+    expect(screen.getByText("Total")).toBeInTheDocument();
+  });
+});
+
+test("expands row to show upcoming bills", async () => {
+  const user = userEvent.setup();
+  renderSpendProgress();
+
+  await waitFor(() => {
+    expect(screen.getByText("Utilities")).toBeInTheDocument();
+  });
+
+  // Electricity bill should not be visible initially
+  expect(screen.queryByText("Electricity")).not.toBeInTheDocument();
+
+  // Click the expand chevron on the Utilities row
+  const utilitiesRow = screen.getByText("Utilities").closest("tr")!;
+  const expandCell = utilitiesRow.querySelector("td:first-child")!;
+  await user.click(expandCell);
+
+  await waitFor(() => {
+    expect(screen.getByText("Electricity")).toBeInTheDocument();
+  });
+
+  expect(screen.getByText("2026-04-15")).toBeInTheDocument();
+});

--- a/src/components/__tests__/TestSpendProgress.tsx
+++ b/src/components/__tests__/TestSpendProgress.tsx
@@ -32,7 +32,7 @@ const progressResponse: ProgressResponse = {
   },
   rows: [
     {
-      id: 5,
+      id: "5",
       name: "Groceries",
       actual_spend: "-342.50",
       expected_remaining: "-157.50",
@@ -40,7 +40,7 @@ const progressResponse: ProgressResponse = {
       upcoming_bills: [],
     },
     {
-      id: 8,
+      id: "8",
       name: "Utilities",
       actual_spend: "-89.00",
       expected_remaining: "-45.00",
@@ -54,7 +54,7 @@ const progressResponse: ProgressResponse = {
       ],
     },
     {
-      id: 12,
+      id: "12",
       name: "Entertainment",
       actual_spend: "-50.00",
       expected_remaining: "-30.00",
@@ -165,10 +165,8 @@ test("expands row to show upcoming bills", async () => {
   // Electricity bill should not be visible initially
   expect(screen.queryByText("Electricity")).not.toBeInTheDocument();
 
-  // Click the expand chevron on the Utilities row
-  const utilitiesRow = screen.getByText("Utilities").closest("tr")!;
-  const expandCell = utilitiesRow.querySelector("td:first-child")!;
-  await user.click(expandCell);
+  // Click the expand button on the Utilities row
+  await user.click(screen.getByRole("button", { name: "Expand Utilities" }));
 
   await waitFor(() => {
     expect(screen.getByText("Electricity")).toBeInTheDocument();

--- a/src/data/Progress.ts
+++ b/src/data/Progress.ts
@@ -1,0 +1,32 @@
+export interface ProgressPeriod {
+  from_date: string;
+  to_date: string;
+  label: string;
+}
+
+export interface UpcomingBill {
+  name: string;
+  expected_date: string;
+  expected_amount: string;
+}
+
+export interface ProgressRow {
+  id: number;
+  name: string;
+  actual_spend: string;
+  expected_remaining: string;
+  budget: string | null;
+  upcoming_bills: UpcomingBill[];
+}
+
+export interface ProgressTotals {
+  actual_spend: string;
+  expected_remaining: string;
+  budget: string | null;
+}
+
+export interface ProgressResponse {
+  period: ProgressPeriod;
+  rows: ProgressRow[];
+  totals: ProgressTotals;
+}

--- a/src/data/Progress.ts
+++ b/src/data/Progress.ts
@@ -11,7 +11,7 @@ export interface UpcomingBill {
 }
 
 export interface ProgressRow {
-  id: number;
+  id: string;
   name: string;
   actual_spend: string;
   expected_remaining: string;

--- a/src/hooks/useProgress.ts
+++ b/src/hooks/useProgress.ts
@@ -1,0 +1,35 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { checkStatusAxios } from "../client/CatTrackAPI";
+import { ProgressResponse } from "../data/Progress";
+import { useAxios } from "./AxiosContext";
+
+export type ProgressGroupBy = "category" | "category_group";
+
+interface UseProgressParams {
+  from_date: string | null;
+  to_date: string | null;
+  group_by: ProgressGroupBy;
+}
+
+export function useProgress(params: UseProgressParams) {
+  const axios = useAxios();
+
+  const fetchProgress = (): Promise<ProgressResponse> =>
+    axios
+      .get("/api/progress/", {
+        params: {
+          from_date: params.from_date,
+          to_date: params.to_date,
+          group_by: params.group_by,
+        },
+      })
+      .then(checkStatusAxios)
+      .then((raw) => raw as ProgressResponse);
+
+  return useQuery({
+    queryKey: ["progress", params.from_date, params.to_date, params.group_by],
+    queryFn: fetchProgress,
+    enabled: !!(params.from_date && params.to_date),
+  });
+}


### PR DESCRIPTION
## Summary
- Adds a new `/progress` page showing actual spend vs budget per category (or category group) for a selected time period
- Each row shows a progress bar, spent amount, budget, and expected remaining — with expandable upcoming bills
- Totals summary row at the bottom; group-by toggle (category vs category group); reuses existing period selector
- New data types (`src/data/Progress.ts`), hook (`useProgress`), and components (`SpendProgress`, `SpendProgressTable`)

## Test plan
- [x] `yarn build` passes
- [x] All 127 tests pass (`yarn test`)
- [ ] Manual: navigate to /progress, verify period selector renders immediately
- [ ] Manual: select a period, verify table populates with spend data
- [ ] Manual: toggle between "By Category" and "By Group"
- [ ] Manual: expand a row with upcoming bills

🤖 Generated with [Claude Code](https://claude.com/claude-code)