### PR TITLE
Expose enhanced cross-validation parameters in Preferences UI

### DIFF
--- a/src/components/CrossValidationForm.tsx
+++ b/src/components/CrossValidationForm.tsx
@@ -146,6 +146,10 @@ export function CrossValidationForm({
           <Form.Control.Feedback type="invalid">
             {errors.split_ratio?.message}
           </Form.Control.Feedback>
+          <Form.Text className="text-muted">
+            Fraction of transactions used to train the model; the remainder are
+            held back to validate it.
+          </Form.Text>
         </Form.Group>
         <Form.Group as={Col} sm={3} controlId="implementation">
           <Form.Label>Implementation</Form.Label>
@@ -155,6 +159,10 @@ export function CrossValidationForm({
               EnhancedSklearnCategoriser
             </option>
           </Form.Select>
+          <Form.Text className="text-muted">
+            Enhanced adds probability calibration, confidence gating and
+            sparse-category exclusion on top of the base model.
+          </Form.Text>
         </Form.Group>
         <Form.Group as={Col} sm={3} controlId="alpha">
           <Form.Label>Alpha</Form.Label>
@@ -171,10 +179,18 @@ export function CrossValidationForm({
           <Form.Control.Feedback type="invalid">
             {errors.alpha?.message}
           </Form.Control.Feedback>
+          <Form.Text className="text-muted">
+            L2 regularisation strength for the classifier. Higher values
+            simplify the model and reduce overfitting.
+          </Form.Text>
         </Form.Group>
         <Form.Group as={Col} sm={3} controlId="random_seed">
           <Form.Label>Random seed (optional)</Form.Label>
           <Form.Control type="number" {...register("random_seed")} />
+          <Form.Text className="text-muted">
+            Fixes the train/validation split so a run can be reproduced
+            exactly. Leave blank for a random split.
+          </Form.Text>
         </Form.Group>
       </Row>
       {isEnhanced && (
@@ -201,6 +217,11 @@ export function CrossValidationForm({
                     <Form.Control.Feedback type="invalid">
                       {errors.threshold?.message}
                     </Form.Control.Feedback>
+                    <Form.Text className="text-muted">
+                      Minimum confidence the top category must reach before a
+                      transaction is auto-categorised. Predictions below this go
+                      to manual review. Higher = more conservative.
+                    </Form.Text>
                   </Form.Group>
                   <Form.Group as={Col} sm={4} controlId="margin">
                     <Form.Label>Margin</Form.Label>
@@ -219,6 +240,10 @@ export function CrossValidationForm({
                     <Form.Control.Feedback type="invalid">
                       {errors.margin?.message}
                     </Form.Control.Feedback>
+                    <Form.Text className="text-muted">
+                      How far ahead of the runner-up the top category must be to
+                      be auto-applied. Guards against close, ambiguous calls.
+                    </Form.Text>
                   </Form.Group>
                   <Form.Group as={Col} sm={4} controlId="calibration_cv">
                     <Form.Label>Calibration CV splits</Form.Label>
@@ -235,6 +260,11 @@ export function CrossValidationForm({
                     <Form.Control.Feedback type="invalid">
                       {errors.calibration_cv?.message}
                     </Form.Control.Feedback>
+                    <Form.Text className="text-muted">
+                      Cross-validation folds used to calibrate the predicted
+                      probabilities. Categories with fewer transactions than
+                      this are dropped from training.
+                    </Form.Text>
                   </Form.Group>
                 </Row>
                 <Row className="mb-3">
@@ -253,6 +283,11 @@ export function CrossValidationForm({
                     <Form.Control.Feedback type="invalid">
                       {errors.min_df?.message}
                     </Form.Control.Feedback>
+                    <Form.Text className="text-muted">
+                      Ignore description terms that appear in fewer transactions
+                      than this. A whole number is a transaction count; a
+                      decimal ≤ 1 is a proportion. Raise it to drop rare noise.
+                    </Form.Text>
                   </Form.Group>
                   <Form.Group as={Col} sm={4} controlId="max_df">
                     <Form.Label>Max document frequency</Form.Label>
@@ -269,6 +304,12 @@ export function CrossValidationForm({
                     <Form.Control.Feedback type="invalid">
                       {errors.max_df?.message}
                     </Form.Control.Feedback>
+                    <Form.Text className="text-muted">
+                      Ignore description terms that appear in more transactions
+                      than this. A whole number is a transaction count; a
+                      decimal ≤ 1 is a proportion. Lower it to drop overly
+                      common terms.
+                    </Form.Text>
                   </Form.Group>
                   <Form.Group
                     as={Col}
@@ -289,18 +330,27 @@ export function CrossValidationForm({
                     <Form.Control.Feedback type="invalid">
                       {errors.min_category_samples?.message}
                     </Form.Control.Feedback>
+                    <Form.Text className="text-muted">
+                      Categories with fewer transactions than this are excluded
+                      from training entirely (listed in the results).
+                    </Form.Text>
                   </Form.Group>
                 </Row>
               </Accordion.Body>
             </Accordion.Item>
           </Accordion>
-          <Form.Check
-            type="checkbox"
-            id="compare_against_baseline"
-            label="Compare against SklearnCategoriser baseline"
-            className="mb-3"
-            {...register("compare_against_baseline")}
-          />
+          <Form.Group className="mb-3">
+            <Form.Check
+              type="checkbox"
+              id="compare_against_baseline"
+              label="Compare against SklearnCategoriser baseline"
+              {...register("compare_against_baseline")}
+            />
+            <Form.Text className="text-muted">
+              Also trains the base SklearnCategoriser on the same split and
+              reports how the enhanced model's metrics compare.
+            </Form.Text>
+          </Form.Group>
         </>
       )}
       <Button type="submit" variant="primary" disabled={isRunning}>

--- a/src/components/CrossValidationForm.tsx
+++ b/src/components/CrossValidationForm.tsx
@@ -1,7 +1,10 @@
-import { Button, Col, Form, Row, Spinner } from "react-bootstrap";
+import { Accordion, Button, Col, Form, Row, Spinner } from "react-bootstrap";
 import { SubmitHandler, useForm } from "react-hook-form";
 
-import { CrossValidateRequest } from "../data/CrossValidation";
+import {
+  CrossValidateRequest,
+  ENHANCED_IMPLEMENTATION,
+} from "../data/CrossValidation";
 
 export interface CrossValidationFormProps {
   onSubmit: (request: CrossValidateRequest) => void;
@@ -14,6 +17,22 @@ type FormInputs = {
   split_ratio: string;
   random_seed: string;
   implementation: string;
+  alpha: string;
+  threshold: string;
+  margin: string;
+  min_df: string;
+  max_df: string;
+  calibration_cv: string;
+  min_category_samples: string;
+  compare_against_baseline: boolean;
+};
+
+const toNumberOrUndefined = (value: string): number | undefined => {
+  if (value === "" || value === undefined || value === null) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  return Number.isNaN(parsed) ? undefined : parsed;
 };
 
 export function CrossValidationForm({
@@ -23,24 +42,62 @@ export function CrossValidationForm({
   const {
     register,
     handleSubmit,
+    watch,
     formState: { errors },
   } = useForm<FormInputs>({
     defaultValues: {
       split_ratio: "0.5",
       implementation: "SklearnCategoriser",
       random_seed: "",
+      alpha: "",
+      threshold: "",
+      margin: "",
+      min_df: "",
+      max_df: "",
+      calibration_cv: "",
+      min_category_samples: "",
+      compare_against_baseline: false,
     },
   });
 
+  const implementation = watch("implementation");
+  const isEnhanced = implementation === ENHANCED_IMPLEMENTATION;
+
   const onFormSubmit: SubmitHandler<FormInputs> = (data) => {
+    // Cross-field validation (e.g. min_df <= max_df, threshold > margin) is
+    // left to the backend; surfaced via the existing error-alert path.
     const request: CrossValidateRequest = {
       from_date: data.from_date,
       to_date: data.to_date,
       split_ratio: Number(data.split_ratio),
       implementation: data.implementation,
     };
-    if (data.random_seed) {
-      request.random_seed = Number(data.random_seed);
+    const seed = toNumberOrUndefined(data.random_seed);
+    if (seed !== undefined) {
+      request.random_seed = seed;
+    }
+    const alpha = toNumberOrUndefined(data.alpha);
+    if (alpha !== undefined) {
+      request.alpha = alpha;
+    }
+    if (data.implementation === ENHANCED_IMPLEMENTATION) {
+      const threshold = toNumberOrUndefined(data.threshold);
+      if (threshold !== undefined) request.threshold = threshold;
+      const margin = toNumberOrUndefined(data.margin);
+      if (margin !== undefined) request.margin = margin;
+      const minDf = toNumberOrUndefined(data.min_df);
+      if (minDf !== undefined) request.min_df = minDf;
+      const maxDf = toNumberOrUndefined(data.max_df);
+      if (maxDf !== undefined) request.max_df = maxDf;
+      const calibrationCv = toNumberOrUndefined(data.calibration_cv);
+      if (calibrationCv !== undefined) request.calibration_cv = calibrationCv;
+      const minCategorySamples = toNumberOrUndefined(data.min_category_samples);
+      if (minCategorySamples !== undefined) {
+        request.min_category_samples = minCategorySamples;
+      }
+      if (data.compare_against_baseline) {
+        request.compare_against_baseline = true;
+      }
     }
     onSubmit(request);
   };
@@ -72,7 +129,7 @@ export function CrossValidationForm({
         </Form.Group>
       </Row>
       <Row className="mb-3">
-        <Form.Group as={Col} sm={4} controlId="split_ratio">
+        <Form.Group as={Col} sm={3} controlId="split_ratio">
           <Form.Label>Split ratio</Form.Label>
           <Form.Control
             type="number"
@@ -90,20 +147,162 @@ export function CrossValidationForm({
             {errors.split_ratio?.message}
           </Form.Control.Feedback>
         </Form.Group>
-        <Form.Group as={Col} sm={4} controlId="implementation">
+        <Form.Group as={Col} sm={3} controlId="implementation">
           <Form.Label>Implementation</Form.Label>
           <Form.Select {...register("implementation")}>
             <option value="SklearnCategoriser">SklearnCategoriser</option>
+            <option value="EnhancedSklearnCategoriser">
+              EnhancedSklearnCategoriser
+            </option>
           </Form.Select>
         </Form.Group>
-        <Form.Group as={Col} sm={4} controlId="random_seed">
-          <Form.Label>Random seed (optional)</Form.Label>
+        <Form.Group as={Col} sm={3} controlId="alpha">
+          <Form.Label>Alpha</Form.Label>
           <Form.Control
             type="number"
-            {...register("random_seed")}
+            step={0.0001}
+            min={0}
+            placeholder="0.001 (default)"
+            {...register("alpha", {
+              min: { value: 0, message: "Minimum is 0" },
+            })}
+            isInvalid={!!errors.alpha}
           />
+          <Form.Control.Feedback type="invalid">
+            {errors.alpha?.message}
+          </Form.Control.Feedback>
+        </Form.Group>
+        <Form.Group as={Col} sm={3} controlId="random_seed">
+          <Form.Label>Random seed (optional)</Form.Label>
+          <Form.Control type="number" {...register("random_seed")} />
         </Form.Group>
       </Row>
+      {isEnhanced && (
+        <>
+          <Accordion className="mb-3">
+            <Accordion.Item eventKey="0">
+              <Accordion.Header>Advanced options</Accordion.Header>
+              <Accordion.Body>
+                <Row className="mb-3">
+                  <Form.Group as={Col} sm={4} controlId="threshold">
+                    <Form.Label>Threshold</Form.Label>
+                    <Form.Control
+                      type="number"
+                      step={0.05}
+                      min={0}
+                      max={1}
+                      placeholder="0.6 (default)"
+                      {...register("threshold", {
+                        min: { value: 0, message: "Minimum is 0" },
+                        max: { value: 1, message: "Maximum is 1" },
+                      })}
+                      isInvalid={!!errors.threshold}
+                    />
+                    <Form.Control.Feedback type="invalid">
+                      {errors.threshold?.message}
+                    </Form.Control.Feedback>
+                  </Form.Group>
+                  <Form.Group as={Col} sm={4} controlId="margin">
+                    <Form.Label>Margin</Form.Label>
+                    <Form.Control
+                      type="number"
+                      step={0.05}
+                      min={0}
+                      max={1}
+                      placeholder="0.15 (default)"
+                      {...register("margin", {
+                        min: { value: 0, message: "Minimum is 0" },
+                        max: { value: 1, message: "Maximum is 1" },
+                      })}
+                      isInvalid={!!errors.margin}
+                    />
+                    <Form.Control.Feedback type="invalid">
+                      {errors.margin?.message}
+                    </Form.Control.Feedback>
+                  </Form.Group>
+                  <Form.Group as={Col} sm={4} controlId="calibration_cv">
+                    <Form.Label>Calibration CV splits</Form.Label>
+                    <Form.Control
+                      type="number"
+                      step={1}
+                      min={2}
+                      placeholder="5 (default)"
+                      {...register("calibration_cv", {
+                        min: { value: 2, message: "Minimum is 2" },
+                      })}
+                      isInvalid={!!errors.calibration_cv}
+                    />
+                    <Form.Control.Feedback type="invalid">
+                      {errors.calibration_cv?.message}
+                    </Form.Control.Feedback>
+                  </Form.Group>
+                </Row>
+                <Row className="mb-3">
+                  <Form.Group as={Col} sm={4} controlId="min_df">
+                    <Form.Label>Min document frequency</Form.Label>
+                    <Form.Control
+                      type="number"
+                      step={1}
+                      min={0}
+                      placeholder="1 (default)"
+                      {...register("min_df", {
+                        min: { value: 0, message: "Must be non-negative" },
+                      })}
+                      isInvalid={!!errors.min_df}
+                    />
+                    <Form.Control.Feedback type="invalid">
+                      {errors.min_df?.message}
+                    </Form.Control.Feedback>
+                  </Form.Group>
+                  <Form.Group as={Col} sm={4} controlId="max_df">
+                    <Form.Label>Max document frequency</Form.Label>
+                    <Form.Control
+                      type="number"
+                      step={0.05}
+                      min={0}
+                      placeholder="1.0 (default)"
+                      {...register("max_df", {
+                        min: { value: 0, message: "Must be non-negative" },
+                      })}
+                      isInvalid={!!errors.max_df}
+                    />
+                    <Form.Control.Feedback type="invalid">
+                      {errors.max_df?.message}
+                    </Form.Control.Feedback>
+                  </Form.Group>
+                  <Form.Group
+                    as={Col}
+                    sm={4}
+                    controlId="min_category_samples"
+                  >
+                    <Form.Label>Min samples per category</Form.Label>
+                    <Form.Control
+                      type="number"
+                      step={1}
+                      min={1}
+                      placeholder="3 (default)"
+                      {...register("min_category_samples", {
+                        min: { value: 1, message: "Minimum is 1" },
+                      })}
+                      isInvalid={!!errors.min_category_samples}
+                    />
+                    <Form.Control.Feedback type="invalid">
+                      {errors.min_category_samples?.message}
+                    </Form.Control.Feedback>
+                  </Form.Group>
+                </Row>
+              </Accordion.Body>
+            </Accordion.Item>
+          </Accordion>
+          <Form.Check
+            type="checkbox"
+            id="compare_against_baseline"
+            label="Compare against SklearnCategoriser baseline"
+            className="mb-3"
+            {...register("compare_against_baseline")}
+          />
+        </>
+      )}
       <Button type="submit" variant="primary" disabled={isRunning}>
         {isRunning && (
           <Spinner

--- a/src/components/CrossValidationResults.tsx
+++ b/src/components/CrossValidationResults.tsx
@@ -18,6 +18,21 @@ export interface CrossValidationResultsProps {
 
 const FAILED_PAGE_SIZE = 10;
 
+const formatPercent = (value: number | undefined): string =>
+  value === undefined ? "-" : `${(value * 100).toFixed(1)}%`;
+
+const deltaClass = (value: number): string => {
+  if (value > 0) return "text-success";
+  if (value < 0) return "text-danger";
+  return "";
+};
+
+const formatDelta = (value: number): string => {
+  const pct = (value * 100).toFixed(1);
+  const sign = value > 0 ? "+" : "";
+  return `${sign}${pct}%`;
+};
+
 export function CrossValidationResults({
   result,
   onSave,
@@ -41,6 +56,15 @@ export function CrossValidationResults({
     failedPage * FAILED_PAGE_SIZE,
     (failedPage + 1) * FAILED_PAGE_SIZE,
   );
+
+  const hasAutoMetrics = sortedMetrics.some(
+    (metric) => metric.auto_total !== undefined,
+  );
+  const hasCoverage = result.coverage !== undefined;
+  const hasExclusions =
+    result.excluded_categories !== undefined &&
+    result.excluded_categories.length > 0;
+  const comparison = result.comparison;
 
   return (
     <div>
@@ -67,8 +91,109 @@ export function CrossValidationResults({
               <p className="text-muted">Validation set</p>
             </Col>
           </Row>
+          {hasCoverage && (
+            <Row className="mt-3">
+              <Col sm={4}>
+                <h4>{formatPercent(result.coverage)}</h4>
+                <p className="text-muted">Coverage</p>
+              </Col>
+              <Col sm={4}>
+                <h4>{formatPercent(result.auto_precision)}</h4>
+                <p className="text-muted">Auto-precision</p>
+              </Col>
+              <Col sm={4}>
+                <h4>{result.review_count ?? "-"}</h4>
+                <p className="text-muted">Review count</p>
+              </Col>
+            </Row>
+          )}
         </Card.Body>
       </Card>
+
+      {hasExclusions && (
+        <Card className="mb-3">
+          <Card.Header>Excluded Categories</Card.Header>
+          <Card.Body>
+            <p className="text-muted mb-2">
+              Trained on {result.included_transaction_count} transactions across{" "}
+              {result.included_category_count} categories.
+            </p>
+            <Table striped bordered hover size="sm" className="mb-0">
+              <thead>
+                <tr>
+                  <th>Category</th>
+                  <th>Transactions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {result.excluded_categories!.map((excluded) => (
+                  <tr key={excluded.category_name}>
+                    <td>{excluded.category_name}</td>
+                    <td>{excluded.count}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </Card.Body>
+        </Card>
+      )}
+
+      {comparison && (
+        <Card className="mb-3">
+          <Card.Header>Baseline Comparison</Card.Header>
+          <Card.Body>
+            <Table striped bordered hover size="sm" className="mb-2">
+              <thead>
+                <tr>
+                  <th>Metric</th>
+                  <th>{result.implementation}</th>
+                  <th>{comparison.baseline.implementation}</th>
+                  <th>Δ</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Accuracy</td>
+                  <td>{formatPercent(result.accuracy)}</td>
+                  <td>{formatPercent(comparison.baseline.accuracy)}</td>
+                  <td className={deltaClass(comparison.delta.accuracy)}>
+                    {formatDelta(comparison.delta.accuracy)}
+                  </td>
+                </tr>
+                <tr>
+                  <td>Overall accuracy</td>
+                  <td>{formatPercent(result.overall_accuracy)}</td>
+                  <td>
+                    {formatPercent(comparison.baseline.overall_accuracy)}
+                  </td>
+                  <td className={deltaClass(comparison.delta.overall_accuracy)}>
+                    {formatDelta(comparison.delta.overall_accuracy)}
+                  </td>
+                </tr>
+                <tr>
+                  <td>Auto-precision</td>
+                  <td>{formatPercent(result.auto_precision)}</td>
+                  <td>{formatPercent(comparison.baseline.auto_precision)}</td>
+                  <td className={deltaClass(comparison.delta.auto_precision)}>
+                    {formatDelta(comparison.delta.auto_precision)}
+                  </td>
+                </tr>
+                <tr>
+                  <td>Coverage</td>
+                  <td>{formatPercent(result.coverage)}</td>
+                  <td>{formatPercent(comparison.baseline.coverage)}</td>
+                  <td className={deltaClass(comparison.delta.coverage)}>
+                    {formatDelta(comparison.delta.coverage)}
+                  </td>
+                </tr>
+              </tbody>
+            </Table>
+            <p className="text-muted mb-0">
+              Baseline review count: {comparison.baseline.review_count}
+            </p>
+          </Card.Body>
+        </Card>
+      )}
 
       <h5>Per-Category Precision</h5>
       <Table striped bordered hover size="sm" className="mb-3">
@@ -78,6 +203,12 @@ export function CrossValidationResults({
             <th>Correct</th>
             <th>Total</th>
             <th>Precision</th>
+            {hasAutoMetrics && (
+              <>
+                <th>Auto-precision</th>
+                <th>Coverage</th>
+              </>
+            )}
           </tr>
         </thead>
         <tbody>
@@ -87,6 +218,20 @@ export function CrossValidationResults({
               <td>{metric.correct}</td>
               <td>{metric.total}</td>
               <td>{(metric.precision * 100).toFixed(1)}%</td>
+              {hasAutoMetrics && (
+                <>
+                  <td>
+                    {metric.auto_total !== undefined
+                      ? formatPercent(metric.auto_precision)
+                      : ""}
+                  </td>
+                  <td>
+                    {metric.auto_total !== undefined
+                      ? formatPercent(metric.coverage)
+                      : ""}
+                  </td>
+                </>
+              )}
             </tr>
           ))}
         </tbody>

--- a/src/components/Preferences.tsx
+++ b/src/components/Preferences.tsx
@@ -6,6 +6,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import {
   CrossValidateRequest,
   CrossValidateResult,
+  CrossValidateSaveRequest,
   SavedModel,
 } from "../data/CrossValidation";
 import { useCrossValidation } from "../hooks/useCrossValidation";
@@ -21,6 +22,11 @@ export function Preferences(): JSX.Element {
 
   const [isRunning, setIsRunning] = useState(false);
   const [result, setResult] = useState<CrossValidateResult | null>(null);
+  // Hyperparameters aren't echoed back in the CV result, so we cache the
+  // request to forward them on save (training_config drives recalibrate).
+  const [lastRequest, setLastRequest] = useState<CrossValidateRequest | null>(
+    null,
+  );
   const [error, setError] = useState<string | null>(null);
   const [showSaveModal, setShowSaveModal] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
@@ -46,11 +52,13 @@ export function Preferences(): JSX.Element {
     setIsRunning(true);
     setError(null);
     setResult(null);
+    setLastRequest(null);
     setSuccessMessage(null);
     setSavedModel(null);
     try {
       const cvResult = await runCrossValidation(request);
       setResult(cvResult);
+      setLastRequest(request);
     } catch (e: unknown) {
       setError((e as Error).message);
     } finally {
@@ -64,7 +72,32 @@ export function Preferences(): JSX.Element {
     setIsSaving(true);
     setSaveError(undefined);
     try {
-      const request = {
+      const hyperparams: Partial<CrossValidateSaveRequest> = lastRequest
+        ? {
+            ...(lastRequest.threshold !== undefined && {
+              threshold: lastRequest.threshold,
+            }),
+            ...(lastRequest.margin !== undefined && {
+              margin: lastRequest.margin,
+            }),
+            ...(lastRequest.min_df !== undefined && {
+              min_df: lastRequest.min_df,
+            }),
+            ...(lastRequest.max_df !== undefined && {
+              max_df: lastRequest.max_df,
+            }),
+            ...(lastRequest.alpha !== undefined && {
+              alpha: lastRequest.alpha,
+            }),
+            ...(lastRequest.calibration_cv !== undefined && {
+              calibration_cv: lastRequest.calibration_cv,
+            }),
+            ...(lastRequest.min_category_samples !== undefined && {
+              min_category_samples: lastRequest.min_category_samples,
+            }),
+          }
+        : {};
+      const request: CrossValidateSaveRequest = {
         name: values.name,
         from_date: result.from_date,
         to_date: result.to_date,
@@ -75,6 +108,7 @@ export function Preferences(): JSX.Element {
           split_ratio: result.split_ratio,
           random_seed: result.random_seed,
         }),
+        ...hyperparams,
       };
       const saved = await saveModel(request);
       await queryClient.invalidateQueries({ queryKey: ["categorisors"] });
@@ -83,6 +117,7 @@ export function Preferences(): JSX.Element {
       }
       setShowSaveModal(false);
       setResult(null);
+      setLastRequest(null);
       setSavedModel(values.set_as_default ? null : saved);
       setSuccessMessage(
         values.set_as_default

--- a/src/components/__tests__/TestCrossValidationForm.tsx
+++ b/src/components/__tests__/TestCrossValidationForm.tsx
@@ -13,6 +13,13 @@ function fillDates() {
   });
 }
 
+async function selectEnhanced(user: ReturnType<typeof userEvent.setup>) {
+  await user.selectOptions(
+    screen.getByLabelText("Implementation"),
+    "EnhancedSklearnCategoriser",
+  );
+}
+
 describe("CrossValidationForm", () => {
   it("should render all form fields", () => {
     render(<CrossValidationForm onSubmit={vi.fn()} isRunning={false} />);
@@ -21,8 +28,20 @@ describe("CrossValidationForm", () => {
     expect(screen.getByLabelText("To date")).toBeTruthy();
     expect(screen.getByLabelText("Split ratio")).toBeTruthy();
     expect(screen.getByLabelText("Implementation")).toBeTruthy();
+    expect(screen.getByLabelText("Alpha")).toBeTruthy();
     expect(screen.getByLabelText("Random seed (optional)")).toBeTruthy();
     expect(screen.getByText("Run Cross-Validation")).toBeTruthy();
+  });
+
+  it("should offer both implementation options", () => {
+    render(<CrossValidationForm onSubmit={vi.fn()} isRunning={false} />);
+
+    const select = screen.getByLabelText(
+      "Implementation",
+    ) as HTMLSelectElement;
+    const values = Array.from(select.options).map((o) => o.value);
+    expect(values).toContain("SklearnCategoriser");
+    expect(values).toContain("EnhancedSklearnCategoriser");
   });
 
   it("should call onSubmit with correct values", async () => {
@@ -58,6 +77,133 @@ describe("CrossValidationForm", () => {
         expect.objectContaining({ random_seed: 42 }),
       );
     });
+  });
+
+  it("should include alpha for either implementation when provided", async () => {
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(<CrossValidationForm onSubmit={onSubmit} isRunning={false} />);
+
+    fillDates();
+    await user.type(screen.getByLabelText("Alpha"), "0.01");
+    await user.click(screen.getByText("Run Cross-Validation"));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ alpha: 0.01 }),
+      );
+    });
+  });
+
+  it("should hide Enhanced-only fields when SklearnCategoriser is selected", () => {
+    render(<CrossValidationForm onSubmit={vi.fn()} isRunning={false} />);
+
+    expect(screen.queryByText("Advanced options")).toBeNull();
+    expect(
+      screen.queryByLabelText("Compare against SklearnCategoriser baseline"),
+    ).toBeNull();
+  });
+
+  it("should reveal Enhanced-only fields when EnhancedSklearnCategoriser is selected", async () => {
+    const user = userEvent.setup();
+    render(<CrossValidationForm onSubmit={vi.fn()} isRunning={false} />);
+
+    await selectEnhanced(user);
+
+    expect(screen.getByText("Advanced options")).toBeTruthy();
+    expect(
+      screen.getByLabelText("Compare against SklearnCategoriser baseline"),
+    ).toBeTruthy();
+  });
+
+  it("should omit empty advanced fields from the submitted request", async () => {
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(<CrossValidationForm onSubmit={onSubmit} isRunning={false} />);
+
+    fillDates();
+    await selectEnhanced(user);
+    await user.click(screen.getByText("Run Cross-Validation"));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalled();
+    });
+    const request = onSubmit.mock.calls[0][0];
+    expect(request.threshold).toBeUndefined();
+    expect(request.margin).toBeUndefined();
+    expect(request.min_df).toBeUndefined();
+    expect(request.max_df).toBeUndefined();
+    expect(request.calibration_cv).toBeUndefined();
+    expect(request.min_category_samples).toBeUndefined();
+    expect(request.compare_against_baseline).toBeUndefined();
+  });
+
+  it("should forward filled advanced fields as numbers and baseline toggle as boolean", async () => {
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(<CrossValidationForm onSubmit={onSubmit} isRunning={false} />);
+
+    fillDates();
+    await selectEnhanced(user);
+    await user.click(screen.getByText("Advanced options"));
+
+    await user.type(screen.getByLabelText("Threshold"), "0.55");
+    await user.type(screen.getByLabelText("Margin"), "0.1");
+    await user.type(screen.getByLabelText("Calibration CV splits"), "3");
+    await user.type(screen.getByLabelText("Min document frequency"), "2");
+    await user.type(screen.getByLabelText("Max document frequency"), "0.9");
+    await user.type(screen.getByLabelText("Min samples per category"), "4");
+    await user.click(
+      screen.getByLabelText("Compare against SklearnCategoriser baseline"),
+    );
+
+    await user.click(screen.getByText("Run Cross-Validation"));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          implementation: "EnhancedSklearnCategoriser",
+          threshold: 0.55,
+          margin: 0.1,
+          calibration_cv: 3,
+          min_df: 2,
+          max_df: 0.9,
+          min_category_samples: 4,
+          compare_against_baseline: true,
+        }),
+      );
+    });
+  });
+
+  it("should not forward Enhanced-only values when switching back to SklearnCategoriser", async () => {
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(<CrossValidationForm onSubmit={onSubmit} isRunning={false} />);
+
+    fillDates();
+    await selectEnhanced(user);
+    await user.click(screen.getByText("Advanced options"));
+    await user.type(screen.getByLabelText("Threshold"), "0.7");
+    await user.click(
+      screen.getByLabelText("Compare against SklearnCategoriser baseline"),
+    );
+
+    // Switch back to the default implementation. react-hook-form keeps the
+    // threshold value in state, but it must not be forwarded.
+    await user.selectOptions(
+      screen.getByLabelText("Implementation"),
+      "SklearnCategoriser",
+    );
+
+    await user.click(screen.getByText("Run Cross-Validation"));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalled();
+    });
+    const request = onSubmit.mock.calls[0][0];
+    expect(request.implementation).toBe("SklearnCategoriser");
+    expect(request.threshold).toBeUndefined();
+    expect(request.compare_against_baseline).toBeUndefined();
   });
 
   it("should disable submit button when running", () => {

--- a/src/components/__tests__/TestCrossValidationResults.tsx
+++ b/src/components/__tests__/TestCrossValidationResults.tsx
@@ -141,6 +141,96 @@ describe("CrossValidationResults", () => {
     expect(screen.queryByText(/Failed Predictions/)).toBeNull();
   });
 
+  it("should not render enhanced metric sections for a legacy response", () => {
+    render(<CrossValidationResults result={baseResult} onSave={vi.fn()} />);
+
+    expect(screen.queryByText("Coverage")).toBeNull();
+    expect(screen.queryByText("Auto-precision")).toBeNull();
+    expect(screen.queryByText("Excluded Categories")).toBeNull();
+    expect(screen.queryByText("Baseline Comparison")).toBeNull();
+  });
+
+  it("should render coverage, excluded-categories and baseline-comparison when present", () => {
+    const enhanced: CrossValidateResult = {
+      ...baseResult,
+      implementation: "EnhancedSklearnCategoriser",
+      overall_accuracy: 0.87,
+      auto_matched: 100,
+      auto_precision: 0.95,
+      coverage: 0.8,
+      review_count: 30,
+      included_category_count: 2,
+      included_transaction_count: 140,
+      excluded_categories: [{ category_name: "Rare", count: 1 }],
+      category_metrics: [
+        {
+          category_name: "Shopping",
+          correct: 45,
+          total: 50,
+          precision: 0.9,
+          auto_correct: 40,
+          auto_total: 42,
+          auto_precision: 0.952,
+          coverage: 0.84,
+        },
+      ],
+      comparison: {
+        baseline: {
+          implementation: "SklearnCategoriser",
+          accuracy: 0.8,
+          overall_accuracy: 0.8,
+          auto_precision: 0.85,
+          coverage: 0.7,
+          review_count: 45,
+        },
+        delta: {
+          accuracy: 0.07,
+          overall_accuracy: 0.07,
+          auto_precision: 0.1,
+          coverage: 0.1,
+        },
+      },
+    };
+
+    render(<CrossValidationResults result={enhanced} onSave={vi.fn()} />);
+
+    // Coverage tile row (label appears for tile + comparison row + per-cat col)
+    expect(screen.getAllByText("Coverage").length).toBeGreaterThan(0);
+    expect(screen.getByText("Review count")).toBeTruthy();
+    expect(screen.getAllByText("80.0%").length).toBeGreaterThan(0);
+
+    // Excluded categories card
+    expect(screen.getByText("Excluded Categories")).toBeTruthy();
+    expect(screen.getByText("Rare")).toBeTruthy();
+    expect(
+      screen.getByText(/Trained on 140 transactions across 2 categories/),
+    ).toBeTruthy();
+
+    // Baseline comparison card
+    expect(screen.getByText("Baseline Comparison")).toBeTruthy();
+    expect(screen.getAllByText("+7.0%").length).toBeGreaterThan(0);
+    expect(screen.getByText(/Baseline review count: 45/)).toBeTruthy();
+
+    // Extra per-category columns (label appears in tile + comparison + col)
+    expect(screen.getAllByText("Auto-precision").length).toBeGreaterThan(0);
+  });
+
+  it("should not render excluded-categories card when list is empty", () => {
+    const enhanced: CrossValidateResult = {
+      ...baseResult,
+      coverage: 0.9,
+      auto_precision: 0.92,
+      review_count: 10,
+      included_category_count: 2,
+      included_transaction_count: 150,
+      excluded_categories: [],
+    };
+
+    render(<CrossValidationResults result={enhanced} onSave={vi.fn()} />);
+
+    expect(screen.queryByText("Excluded Categories")).toBeNull();
+  });
+
   it("should reset pagination when result changes", async () => {
     const user = userEvent.setup();
     const failed = Array.from({ length: 15 }, (_, i) =>

--- a/src/components/__tests__/TestPreferences.tsx
+++ b/src/components/__tests__/TestPreferences.tsx
@@ -350,6 +350,143 @@ describe("Preferences", () => {
     });
   });
 
+  it("should forward advanced params to cross_validate_save and omit compare_against_baseline", async () => {
+    const user = userEvent.setup();
+    let lastCvRequest: Record<string, unknown> | null = null;
+    let lastSaveRequest: Record<string, unknown> | null = null;
+
+    renderWithProviders(
+      <Preferences />,
+      undefined,
+      (mockAdapter: AxiosMockAdapter) => {
+        setupDefaultModelMocks(mockAdapter);
+        mockAdapter
+          .onPost("/api/categorisor/cross_validate/")
+          .reply((config) => {
+            lastCvRequest = JSON.parse(config.data);
+            return [
+              200,
+              { ...mockResult, implementation: "EnhancedSklearnCategoriser" },
+            ];
+          });
+        mockAdapter
+          .onPost("/api/categorisor/cross_validate_save/")
+          .reply((config) => {
+            lastSaveRequest = JSON.parse(config.data);
+            return [201, mockSavedModel];
+          });
+      },
+    );
+
+    fireEvent.change(screen.getByLabelText("From date"), {
+      target: { value: "2025-01-01" },
+    });
+    fireEvent.change(screen.getByLabelText("To date"), {
+      target: { value: "2025-12-31" },
+    });
+    await user.selectOptions(
+      screen.getByLabelText("Implementation"),
+      "EnhancedSklearnCategoriser",
+    );
+    await user.click(screen.getByText("Advanced options"));
+    await user.type(screen.getByLabelText("Threshold"), "0.55");
+    await user.type(screen.getByLabelText("Min samples per category"), "3");
+    await user.click(
+      screen.getByLabelText("Compare against SklearnCategoriser baseline"),
+    );
+    await user.click(screen.getByText("Run Cross-Validation"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Save Model")).toBeTruthy();
+    });
+    expect(lastCvRequest).toMatchObject({
+      threshold: 0.55,
+      min_category_samples: 3,
+      compare_against_baseline: true,
+    });
+
+    await user.click(screen.getByText("Save Model"));
+    await waitFor(() => {
+      expect(screen.getByLabelText("Model name")).toBeTruthy();
+    });
+    await user.type(screen.getByLabelText("Model name"), "enhanced-model");
+    await user.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(lastSaveRequest).not.toBeNull();
+    });
+    expect(lastSaveRequest).toMatchObject({
+      name: "enhanced-model",
+      implementation: "EnhancedSklearnCategoriser",
+      threshold: 0.55,
+      min_category_samples: 3,
+    });
+    expect(lastSaveRequest).not.toHaveProperty("compare_against_baseline");
+  });
+
+  it("should clear cached hyperparameters when a new cross-validation runs without them", async () => {
+    const user = userEvent.setup();
+    let lastSaveRequest: Record<string, unknown> | null = null;
+
+    renderWithProviders(
+      <Preferences />,
+      undefined,
+      (mockAdapter: AxiosMockAdapter) => {
+        setupDefaultModelMocks(mockAdapter);
+        mockAdapter
+          .onPost("/api/categorisor/cross_validate/")
+          .reply(200, mockResult);
+        mockAdapter
+          .onPost("/api/categorisor/cross_validate_save/")
+          .reply((config) => {
+            lastSaveRequest = JSON.parse(config.data);
+            return [201, mockSavedModel];
+          });
+      },
+    );
+
+    // First run: Enhanced + threshold
+    fireEvent.change(screen.getByLabelText("From date"), {
+      target: { value: "2025-01-01" },
+    });
+    fireEvent.change(screen.getByLabelText("To date"), {
+      target: { value: "2025-12-31" },
+    });
+    await user.selectOptions(
+      screen.getByLabelText("Implementation"),
+      "EnhancedSklearnCategoriser",
+    );
+    await user.click(screen.getByText("Advanced options"));
+    await user.type(screen.getByLabelText("Threshold"), "0.8");
+    await user.click(screen.getByText("Run Cross-Validation"));
+    await waitFor(() => {
+      expect(screen.getByText("Save Model")).toBeTruthy();
+    });
+
+    // Second run: switch back to default, do not re-fill threshold
+    await user.selectOptions(
+      screen.getByLabelText("Implementation"),
+      "SklearnCategoriser",
+    );
+    await user.click(screen.getByText("Run Cross-Validation"));
+    await waitFor(() => {
+      expect(screen.getByText("Save Model")).toBeTruthy();
+    });
+
+    await user.click(screen.getByText("Save Model"));
+    await waitFor(() => {
+      expect(screen.getByLabelText("Model name")).toBeTruthy();
+    });
+    await user.type(screen.getByLabelText("Model name"), "plain-model");
+    await user.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(lastSaveRequest).not.toBeNull();
+    });
+    // Advanced params from the earlier run must not leak into this save.
+    expect(lastSaveRequest).not.toHaveProperty("threshold");
+  });
+
   it("should set saved model as default", async () => {
     const user = userEvent.setup();
     renderWithProviders(<Preferences />, undefined, setup);

--- a/src/data/CrossValidation.ts
+++ b/src/data/CrossValidation.ts
@@ -1,9 +1,19 @@
+export const ENHANCED_IMPLEMENTATION = "EnhancedSklearnCategoriser";
+
 export interface CrossValidateRequest {
   from_date: string;
   to_date: string;
   split_ratio: number;
   random_seed?: number;
   implementation: string;
+  threshold?: number;
+  margin?: number;
+  min_df?: number;
+  max_df?: number;
+  alpha?: number;
+  calibration_cv?: number;
+  min_category_samples?: number;
+  compare_against_baseline?: boolean;
 }
 
 export interface CrossValidateSaveRequest {
@@ -15,6 +25,13 @@ export interface CrossValidateSaveRequest {
   implementation: string;
   split_ratio?: number;
   random_seed?: number;
+  threshold?: number;
+  margin?: number;
+  min_df?: number;
+  max_df?: number;
+  alpha?: number;
+  calibration_cv?: number;
+  min_category_samples?: number;
 }
 
 export interface CategoryMetric {
@@ -22,6 +39,10 @@ export interface CategoryMetric {
   correct: number;
   total: number;
   precision: number;
+  auto_correct?: number;
+  auto_total?: number;
+  auto_precision?: number;
+  coverage?: number;
 }
 
 export interface FailedPrediction {
@@ -42,6 +63,32 @@ export interface FailedPrediction {
   };
 }
 
+export interface ExcludedCategory {
+  category_name: string;
+  count: number;
+}
+
+export interface ComparisonBaseline {
+  implementation: string;
+  accuracy: number;
+  overall_accuracy: number;
+  auto_precision: number;
+  coverage: number;
+  review_count: number;
+}
+
+export interface ComparisonDelta {
+  accuracy: number;
+  overall_accuracy: number;
+  auto_precision: number;
+  coverage: number;
+}
+
+export interface CrossValidateComparison {
+  baseline: ComparisonBaseline;
+  delta: ComparisonDelta;
+}
+
 export interface CrossValidateResult {
   status: "ok";
   random_seed: number;
@@ -56,6 +103,15 @@ export interface CrossValidateResult {
   matched: number;
   category_metrics: CategoryMetric[];
   failed: FailedPrediction[];
+  overall_accuracy?: number;
+  auto_matched?: number;
+  auto_precision?: number;
+  coverage?: number;
+  review_count?: number;
+  excluded_categories?: ExcludedCategory[];
+  included_category_count?: number;
+  included_transaction_count?: number;
+  comparison?: CrossValidateComparison;
 }
 
 export interface CrossValidateError {


### PR DESCRIPTION
## Summary

The backend ([dmkent/cattrack@4f17802c](https://github.com/dmkent/cattrack/commit/4f17802c7e32c27da42f536984c099dcb2c05c71)) added an `EnhancedSklearnCategoriser` implementation and extended the `cross_validate` / `cross_validate_save` endpoints with optional training hyperparameters plus richer response metrics (coverage, auto-precision, excluded categories, baseline comparison). The client previously hard-coded `SklearnCategoriser` and surfaced only accuracy tiles, so none of this was reachable. This PR wires the new inputs and outputs into the Preferences page.

## What changed

- **Form** (`CrossValidationForm.tsx`): added `EnhancedSklearnCategoriser` to the implementation selector; promoted `alpha` to a top-level field (applies to both implementations); added a collapsible **Advanced options** accordion (`threshold`, `margin`, `min_df`, `max_df`, `calibration_cv`, `min_category_samples`) and a `compare_against_baseline` checkbox, both shown only for the enhanced model. Blank fields are omitted from the request (backend defaults apply); enhanced-only values are not forwarded when the implementation is switched back to `SklearnCategoriser`.
- **Results** (`CrossValidationResults.tsx`): added coverage / auto-precision / review-count tiles, an excluded-categories card, a baseline-comparison card (enhanced vs. baseline with coloured deltas), and auto-precision/coverage columns on the per-category table. Every new section is guarded so legacy `SklearnCategoriser` responses render exactly as before.
- **Threading** (`Preferences.tsx`): the hyperparameters used for a run are cached and forwarded to `cross_validate_save` (minus `compare_against_baseline`), so they persist in the model's `training_config` — which the `recalibrate` endpoint reuses. No separate recalibrate UI is needed.
- **Types** (`data/CrossValidation.ts`): extended request/response interfaces with the new optional fields and added `ExcludedCategory` / comparison types. All additions are optional for backward compatibility.

## Reviewer notes

- Hyperparameters aren't echoed back in the CV response, so `Preferences` caches the request that produced the current result and forwards it on save. The cache is cleared whenever the result is cleared, so stale params can't leak into a later save.
- Client-side cross-field validation (e.g. `min_df <= max_df`, `threshold > margin`) is intentionally out of scope; the backend returns 400 and the existing error alert surfaces it.

## Test plan

- [x] `yarn test` — 173/173 pass (11 new tests covering form conditional rendering, param coercion/omission, results sections, and save-threading)
- [x] `yarn build` — type-check passes
- [ ] Manual smoke test against a backend with the commit applied: run CV with both implementations, verify enhanced metrics/cards appear, confirm save payload includes the hyperparameters and omits `compare_against_baseline`

🤖 Generated with [Claude Code](https://claude.com/claude-code)