### PR TITLE
Add Dependabot config with 7-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` to enable Dependabot for the `npm` ecosystem
- Configures a 7-day cooldown so PRs are only opened for versions that have been published for at least 7 days

## Test plan
- [ ] Verify Dependabot is enabled in the repo's Security settings
- [ ] Confirm no immediate PRs are opened for packages published within the last 7 days

🤖 Generated with [Claude Code](https://claude.com/claude-code)