### PR TITLE
Add dependency groups to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,34 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-*"
+          - "@types/react"
+          - "@types/react-dom"
+      testing:
+        patterns:
+          - "@testing-library/*"
+          - "vitest"
+          - "@vitest/*"
+          - "jsdom"
+          - "axios-mock-adapter"
+      typescript:
+        patterns:
+          - "typescript"
+          - "typescript-eslint"
+          - "@typescript-eslint/*"
+          - "@types/*"
+      linting:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "prettier"
+          - "prettier-*"
+          - "@trivago/prettier-plugin-sort-imports"
+      vite:
+        patterns:
+          - "vite"
+          - "@vitejs/*"


### PR DESCRIPTION
## Summary
- Groups related dependencies so Dependabot opens one PR per group rather than one per package
- Groups: `react`, `testing`, `typescript`, `linting`, `vite`

## Test plan
- [ ] Confirm next Dependabot run batches updates by group

🤖 Generated with [Claude Code](https://claude.com/claude-code)